### PR TITLE
Minimal changes to compile with rustc nightly (0.11-pre 33c3edd 2014-05-23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,17 @@ A simple example
 ----------------
 
 ```rust
-extern mod zip;
+extern crate zip;
 
-use std::os;
-use std::rt::io::*;
-use zip::*;
+use std::{os, io};
 
 fn main() {
     let args = os::args();
 
     // open a zip archive
-    let zip_path = Path(args[1]);
-    let mut in_stream = file::open(&zip_path, Open, Read).unwrap();
-    let mut z = ZipReader::new(in_stream).unwrap();
+    let zip_path = Path::new(args.as_slice()[1].as_slice());
+    let in_stream = io::File::open(&zip_path).unwrap();
+    let mut z = zip::ZipReader::new(in_stream).unwrap();
 
     // list files in archive
     for i in z.iter() {
@@ -31,11 +29,11 @@ fn main() {
     }
 
     // if we have two arguments, extract file
-    if (args.len() > 2) {
-        let dest_path = Path(args[2]);
-        let mut out_stream = file::open(&dest_path, CreateOrTruncate, Write).unwrap();
-        let f = z.get_file_info(args[2]).unwrap();
-        z.extract(&f, &mut out_stream);
+    if args.len() > 2 {
+        let dest_path = Path::new(args.as_slice()[2].as_slice());
+        let mut out_stream = io::File::create(&dest_path).unwrap();
+        let f = z.get_file_info(args.as_slice()[2].as_slice()).unwrap();
+        let _ = z.extract(&f, &mut out_stream);
     }
 }
 ```

--- a/src/zip/crc32.rs
+++ b/src/zip/crc32.rs
@@ -71,7 +71,7 @@ pub fn crc32(buf: &[u8]) -> u32 {
     let mut r = 0xffffffffu32;
     for byte in buf.iter() {
         let idx = byte ^ ((r & 0xff) as u8);
-        r = (r >> 8) ^ CRCTABLE[idx];
+        r = (r >> 8) ^ CRCTABLE[idx as uint];
     }
 
     return r ^ 0xffffffffu32;


### PR DESCRIPTION
It seems that this is currently the only Rust-only library for ZIP processing, but also fallen into disrepair. With this PR it should compile fine.
