### PR TITLE
Fix build errors on nightly rust

### DIFF
--- a/src/zip/reader.rs
+++ b/src/zip/reader.rs
@@ -167,10 +167,8 @@ impl<R:Reader+Seek> ZipReader<R> {
 
     fn decompress(&mut self, data: Vec<u8>, len:usize, crc32: u32) -> Result<Vec<u8>, ZipError> 
     {        
-
-        //let bytes :u8 = flate::inflate_bytes(&data[..]);
         let bytes = match flate::inflate_bytes(&data[..])
-        {            
+        {
             Ok(decompressed) => decompressed,
             Err(what) => return Err(ZipError::DecompressionFailure)
         };

--- a/src/zip/reader.rs
+++ b/src/zip/reader.rs
@@ -166,11 +166,13 @@ impl<R:Reader+Seek> ZipReader<R> {
     }
 
     fn decompress(&mut self, data: Vec<u8>, len:usize, crc32: u32) -> Result<Vec<u8>, ZipError> 
-    {
+    {        
+
+        //let bytes :u8 = flate::inflate_bytes(&data[..]);
         let bytes = match flate::inflate_bytes(&data[..])
-        {
-            Some(ok) => ok,
-            None => return Err(ZipError::DecompressionFailure)
+        {            
+            Ok(decompressed) => decompressed,
+            Err(what) => return Err(ZipError::DecompressionFailure)
         };
         if crc32 != 0 && crc32 != crc32::crc32(&bytes){
             return Err(ZipError::CrcError);


### PR DESCRIPTION
rustc 1.0.0-nightly (ea8b82e90 2015-03-17) (built 2015-03-18) the build has  passed, but a lot of warning still exist.
